### PR TITLE
fix: close docblock + fix type

### DIFF
--- a/src/StatusField.php
+++ b/src/StatusField.php
@@ -12,6 +12,8 @@ class StatusField extends Field
 
     /**
      * The field's component.
+     *
+     * @var string
      */
     public $component = 'nova-status-field';
 

--- a/src/StatusField.php
+++ b/src/StatusField.php
@@ -13,7 +13,7 @@ class StatusField extends Field
     /**
      * The field's component.
      */
-    public string $component = 'nova-status-field';
+    public $component = 'nova-status-field';
 
     /**
      * Define the icons to use for each status.

--- a/src/StatusField.php
+++ b/src/StatusField.php
@@ -12,6 +12,7 @@ class StatusField extends Field
 
     /**
      * The field's component.
+     */
     public string $component = 'nova-status-field';
 
     /**


### PR DESCRIPTION
Seems like it's still working, however it looks broken in editors and Github: https://github.com/marcobax/nova-status-field/blob/master/src/StatusField.php#L14-L15

Also, the `Laravel\Nova\Element` is typed `string` from the docblock and not as a native type. This is also breaking the package.